### PR TITLE
Configure container access

### DIFF
--- a/NSMetadataQueryUbiquitousExternalDocumentsTest/Info.plist
+++ b/NSMetadataQueryUbiquitousExternalDocumentsTest/Info.plist
@@ -22,6 +22,18 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSUbiquitousContainers</key>
+	<dict>
+		<key>iCloud.com.stevemarshall.AnnotateML</key>
+		<dict>
+			<key>NSUbiquitousContainerIsDocumentScopePublic</key>
+			<true/>
+			<key>NSUbiquitousContainerName</key>
+			<string>AnnotateML</string>
+			<key>NSUbiquitousContainerSupportedFolderLevels</key>
+			<string>ANY</string>
+		</dict>
+	</dict>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/NSMetadataQueryUbiquitousExternalDocumentsTest/NSMetadataQueryUbiquitousExternalDocumentsTest.entitlements
+++ b/NSMetadataQueryUbiquitousExternalDocumentsTest/NSMetadataQueryUbiquitousExternalDocumentsTest.entitlements
@@ -3,12 +3,16 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.developer.icloud-container-identifiers</key>
-	<array/>
+	<array>
+		<string>iCloud.com.stevemarshall.AnnotateML</string>
+	</array>
 	<key>com.apple.developer.icloud-services</key>
 	<array>
 		<string>CloudDocuments</string>
 	</array>
 	<key>com.apple.developer.ubiquity-container-identifiers</key>
-	<array/>
+	<array>
+		<string>iCloud.com.stevemarshall.AnnotateML</string>
+	</array>
 </dict>
 </plist>

--- a/NSMetadataQueryUbiquitousExternalDocumentsTest/NSMetadataQueryUbiquitousExternalDocumentsTestApp.swift
+++ b/NSMetadataQueryUbiquitousExternalDocumentsTest/NSMetadataQueryUbiquitousExternalDocumentsTestApp.swift
@@ -13,6 +13,8 @@ struct NSMetadataQueryUbiquitousExternalDocumentsTestApp: App {
     @State private var fileMonitor: AnyCancellable? = nil
     @State private var foundItems = [NSMetadataItem]()
 
+    @State private var rootURL: URL? = nil
+
     var body: some Scene {
         WindowGroup {
             NavigationView {
@@ -110,7 +112,8 @@ extension NSMetadataQueryUbiquitousExternalDocumentsTestApp {
             }
 
         query.searchScopes = [
-            NSMetadataQueryAccessibleUbiquitousExternalDocumentsScope
+            NSMetadataQueryAccessibleUbiquitousExternalDocumentsScope,
+            rootURL as Any
         ]
         query.predicate = NSPredicate(
             format: "%K LIKE %@",

--- a/NSMetadataQueryUbiquitousExternalDocumentsTest/NSMetadataQueryUbiquitousExternalDocumentsTestApp.swift
+++ b/NSMetadataQueryUbiquitousExternalDocumentsTest/NSMetadataQueryUbiquitousExternalDocumentsTestApp.swift
@@ -4,8 +4,8 @@ import UniformTypeIdentifiers
 
 @main
 struct NSMetadataQueryUbiquitousExternalDocumentsTestApp: App {
-    @State private var adding: AddMode? = nil
-    @State private var addedItems = [URL]()
+    @State private var importing: Importing? = nil
+    @State private var importedItems = [URL]()
 
     @State private var query = NSMetadataQuery()
     @State private var fileMonitor: AnyCancellable? = nil
@@ -15,9 +15,9 @@ struct NSMetadataQueryUbiquitousExternalDocumentsTestApp: App {
         WindowGroup {
             NavigationView {
                 List {
-                    Section("Added items") {
-                        ForEach(addedItems, id: \.absoluteString) { added in
-                            Text(added.lastPathComponent)
+                    Section("Imported items") {
+                        ForEach(importedItems, id: \.absoluteString) { imported in
+                            Text(imported.lastPathComponent)
                         }
                     }
 
@@ -29,20 +29,20 @@ struct NSMetadataQueryUbiquitousExternalDocumentsTestApp: App {
                 }
                 .toolbar {
                     ToolbarItemGroup(placement: .navigationBarTrailing) {
-                        Button(action: { adding = .file }, label: {
-                            Label("Add file", systemImage: "doc.badge.plus")
+                        Button(action: { importing = .file }, label: {
+                            Label("Import file", systemImage: "arrow.down.doc")
                         })
-                        Button(action: { adding = .folder }, label: {
-                            Label("Add folder", systemImage: "folder.badge.plus")
+                        Button(action: { importing = .folder }, label: {
+                            Label("Import folder", systemImage: "square.and.arrow.down")
                         })
                     }
                 }
                 .fileImporter(
                     isPresented: Binding(
-                        get: { adding != nil },
-                        set: { _ in adding = nil }
+                        get: { importing != nil },
+                        set: { _ in importing = nil }
                     ),
-                    allowedContentTypes: adding?.allowedContentTypes ?? [],
+                    allowedContentTypes: importing?.allowedContentTypes ?? [],
                     allowsMultipleSelection: true,
                     onCompletion: importFiles
                 )
@@ -57,7 +57,7 @@ extension NSMetadataQueryUbiquitousExternalDocumentsTestApp {
         guard case .success(let urls) = result else {
             return
         }
-        addedItems.append(
+        importedItems.append(
             contentsOf: urls
         )
         findAccessibleFiles()
@@ -116,7 +116,7 @@ extension NSMetadataQueryUbiquitousExternalDocumentsTestApp {
 }
 
 extension NSMetadataQueryUbiquitousExternalDocumentsTestApp {
-    private enum AddMode {
+    private enum Importing {
         case folder
         case file
 

--- a/NSMetadataQueryUbiquitousExternalDocumentsTest/NSMetadataQueryUbiquitousExternalDocumentsTestApp.swift
+++ b/NSMetadataQueryUbiquitousExternalDocumentsTest/NSMetadataQueryUbiquitousExternalDocumentsTestApp.swift
@@ -65,7 +65,19 @@ extension NSMetadataQueryUbiquitousExternalDocumentsTestApp {
 }
 
 extension NSMetadataQueryUbiquitousExternalDocumentsTestApp {
+    func configureUbiquityAccess(to container: String? = nil) {
+        DispatchQueue.global().async {
+            guard let _ = FileManager.default.url(forUbiquityContainerIdentifier: container) else {
+                print("⛔️ Failed to configure iCloud container URL for: \(container ?? "nil")\n"
+                        + "Make sure your iCloud is available and run again.")
+                return
+            }
+            print("Successfully configured iCloud container?")
+        }
+    }
+
     func findAccessibleFiles() {
+        configureUbiquityAccess(to: "iCloud.com.stevemarshall.AnnotateML")
         query.stop()
         fileMonitor?.cancel()
 


### PR DESCRIPTION
With an iCloud container configured, the app can find files in its own container… But still not files that are imported.

This change:

- Configures an iCloud container both in XML and code
- Ensures the query is searching the container's directory
- Adds the ability to add files in the iCloud container